### PR TITLE
grammar: import from Snapcraft (CRAFT-818)

### DIFF
--- a/craft_grammar/__init__.py
+++ b/craft_grammar/__init__.py
@@ -18,3 +18,24 @@
 """Enhance part definitions with advanced grammar."""
 
 __version__ = "1.0.0"
+
+
+from . import errors
+from ._compound import CompoundStatement
+from ._on import OnStatement
+from ._processor import GrammarProcessor
+from ._statement import CallStack, Grammar, Statement
+from ._to import ToStatement
+from ._try import TryStatement
+
+__all__ = [
+    "errors",
+    "CallStack",
+    "CompoundStatement",
+    "Grammar",
+    "GrammarProcessor",
+    "OnStatement",
+    "Statement",
+    "ToStatement",
+    "TryStatement",
+]

--- a/craft_grammar/_compound.py
+++ b/craft_grammar/_compound.py
@@ -1,0 +1,70 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2018, 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Compound Statement for Craft Grammar."""
+
+from typing import TYPE_CHECKING, List
+
+from overrides import overrides
+
+from ._statement import CallStack, Grammar, Statement
+
+if TYPE_CHECKING:
+    from ._processor import GrammarProcessor
+
+
+class CompoundStatement(Statement):
+    """Multiple statements that need to be treated as a group."""
+
+    def __init__(
+        self,
+        *,
+        statements: List[Statement],
+        body: Grammar,
+        processor: "GrammarProcessor",
+        call_stack: CallStack = None,
+    ) -> None:
+        """Create an CompoundStatement instance.
+
+        :param statements: List of compound statements
+        :param body: The body of the clause.
+        :param processor: GrammarProcessor to use for processing this statement.
+        :param call_stack: Call stack leading to this statement.
+        """
+        super().__init__(body=body, processor=processor, call_stack=call_stack)
+
+        self.statements = statements
+
+    @overrides
+    def check(self) -> bool:
+        for statement in self.statements:
+            if not statement.check():
+                return False
+
+        return True
+
+    def __eq__(self, other) -> bool:
+        if type(other) is type(self):
+            return self.statements == other.statements
+
+        return False
+
+    def __str__(self) -> str:
+        representation = ""
+        for statement in self.statements:
+            representation += f"{statement!s} "
+
+        return representation.strip()

--- a/craft_grammar/_on.py
+++ b/craft_grammar/_on.py
@@ -1,0 +1,102 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017, 2018, 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""On Statement for Craft Grammar."""
+
+import re
+from typing import TYPE_CHECKING, Set
+
+from overrides import overrides
+
+from ._statement import CallStack, Grammar, Statement
+from .errors import OnStatementSyntaxError
+
+if TYPE_CHECKING:
+    from ._processor import GrammarProcessor
+
+_SELECTOR_PATTERN = re.compile(r"\Aon\s+([^,\s](?:,?[^,]+)*)\Z")
+_WHITESPACE_PATTERN = re.compile(r"\A.*\s.*\Z")
+
+
+class OnStatement(Statement):
+    """Process an 'on' statement in the grammar."""
+
+    def __init__(
+        self,
+        *,
+        on_statement: str,
+        body: Grammar,
+        processor: "GrammarProcessor",
+        call_stack: CallStack = None,
+    ) -> None:
+        """Create an OnStatement instance.
+
+        :param on_statement: The 'on <selectors>' part of the clause.
+        :param body: The body of the clause.
+        :param processor: GrammarProcessor to use for processing
+                                         this statement.
+        :param call_stack: Call stack leading to this statement.
+        :param arch: the architecture the system is on.
+        """
+        super().__init__(body=body, processor=processor, call_stack=call_stack)
+
+        self.selectors = _extract_on_clause_selectors(on_statement)
+
+    @overrides
+    def check(self) -> bool:
+        # The only selector currently supported is the host arch. Since
+        # selectors are matched with an AND, not OR, there should only be one
+        # selector.
+        return (len(self.selectors) == 1) and (self._processor.arch in self.selectors)
+
+    def __eq__(self, other) -> bool:
+        if type(other) is type(self):
+            return self.selectors == other.selectors
+
+        return False
+
+    def __str__(self) -> str:
+        return f"on {','.join(sorted(self.selectors))}"
+
+
+def _extract_on_clause_selectors(on_statement: str) -> Set[str]:
+    """Extract the list of selectors within an on clause.
+
+    :param str on_statement: The 'on <selector>' part of the 'on' clause.
+
+    :return: Selectors found within the 'on' clause.
+
+    For example:
+    >>> _extract_on_clause_selectors('on amd64,i386') == {'amd64', 'i386'}
+    True
+    """
+    match = _SELECTOR_PATTERN.match(on_statement)
+    if match is None:
+        raise OnStatementSyntaxError(on_statement, message="selectors are missing")
+
+    try:
+        selector_group = match.group(1)
+    except IndexError as index_error:
+        raise OnStatementSyntaxError(on_statement) from index_error
+
+    # This could be part of the _SELECTOR_PATTERN, but that would require us
+    # to provide a very generic error when we can try to be more helpful.
+    if _WHITESPACE_PATTERN.match(selector_group):
+        raise OnStatementSyntaxError(
+            on_statement, message="spaces are not allowed in the selectors"
+        )
+
+    return {selector.strip() for selector in selector_group.split(",")}

--- a/craft_grammar/_processor.py
+++ b/craft_grammar/_processor.py
@@ -1,0 +1,289 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017, 2018, 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Craft Grammar's Processor implementation."""
+
+import re
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from ._compound import CompoundStatement
+from ._on import OnStatement
+from ._statement import CallStack, Grammar, Statement
+from ._to import ToStatement
+from ._try import TryStatement
+from .errors import GrammarSyntaxError
+
+_ON_TO_CLAUSE_PATTERN = re.compile(r"(\Aon\s+\S+)\s+(to\s+\S+\Z)")
+_ON_CLAUSE_PATTERN = re.compile(r"\Aon\s+")
+_TO_CLAUSE_PATTERN = re.compile(r"\Ato\s+")
+_TRY_CLAUSE_PATTERN = re.compile(r"\Atry\Z")
+_ELSE_CLAUSE_PATTERN = re.compile(r"\Aelse\Z")
+_ELSE_FAIL_PATTERN = re.compile(r"\Aelse\s+fail\Z")
+
+
+class GrammarProcessor:  # pylint: disable=too-few-public-methods
+    """The GrammarProcessor extracts desired primitives from grammar."""
+
+    def __init__(
+        self,
+        *,
+        checker: Callable[[Any], bool],
+        arch: str,
+        target_arch: str,
+        transformer: Callable[[List[Statement], str, str], str] = None,
+    ) -> None:
+        """Create a new GrammarProcessor.
+
+        :param checker: callable accepting a single primitive,
+                        returning true if it is valid.
+        :param arch: the architecture the system is on.
+        :param target_arch: the architecture the system is to build for.
+        :param transformer: callable accepting a call stack, single
+                            primitive and arch, and returning a
+                            transformed primitive.
+        """
+        self.arch = arch
+        self.target_arch = target_arch
+        self.checker = checker
+
+        if transformer:
+            self._transformer = transformer
+        else:
+            # By default, no transformation
+            self._transformer = lambda s, p, o: p
+
+    def process(self, *, grammar: Grammar, call_stack: CallStack = None) -> List[Any]:
+        """Process grammar and extract desired primitives.
+
+        :param grammar: Unprocessed grammar.
+        :param call_stack: Call stack of statements leading to now.
+
+        :return: Primitives selected
+        """
+        if call_stack is None:
+            call_stack = []
+
+        primitives: List[Any] = []
+        statements = _StatementCollection()
+        statement: Optional[Statement] = None
+
+        for section in grammar:
+            if isinstance(section, str):
+                # If the section is just a string, it's either "else fail" or a
+                # primitive name.
+                if _ELSE_FAIL_PATTERN.match(section):
+                    _handle_else(statement, None)
+                else:
+                    # Processing a string primitive indicates the previous section
+                    # is finalized (if any), process it first before this primitive.
+                    self._process_statement(
+                        statement=statement,
+                        statements=statements,
+                        primitives=primitives,
+                    )
+                    statement = None
+
+                    primitive = self._transformer(call_stack, section, self.target_arch)
+                    primitives.append(primitive)
+            elif isinstance(section, dict):
+                statement, finalized_statement = self._parse_section_dictionary(
+                    call_stack=call_stack,
+                    section=section,
+                    statement=statement,
+                )
+
+                # Process any finalized statement (if any).
+                if finalized_statement is not None:
+                    self._process_statement(
+                        statement=finalized_statement,
+                        statements=statements,
+                        primitives=primitives,
+                    )
+
+                # If this section does not belong to a statement, it is
+                # a primitive to be recorded.
+                if statement is None:
+                    primitives.append(section)
+
+            else:
+                # jsonschema should never let us get here.
+                raise GrammarSyntaxError(
+                    "expected grammar section to be either of type 'str' or "
+                    f"type 'dict', but got {type(section)!r}"
+                )
+
+        # Process the final statement (if any).
+        self._process_statement(
+            statement=statement,
+            statements=statements,
+            primitives=primitives,
+        )
+
+        return primitives
+
+    @staticmethod
+    def _process_statement(
+        *,
+        statement: Optional[Statement],
+        statements: "_StatementCollection",
+        primitives: List[Any],
+    ):
+        if statement is None:
+            return
+
+        statements.add(statement)
+        processed_primitives = statement.process()
+        primitives.extend(processed_primitives)
+
+    def _parse_section_dictionary(
+        self,
+        *,
+        section: Dict[str, Any],
+        statement: Optional[Statement],
+        call_stack: CallStack,
+    ) -> Tuple[Optional[Statement], Optional[Statement]]:
+        finalized_statement: Optional[Statement] = None
+        for key, value in section.items():
+            # Grammar is always written as a list of selectors but the value
+            # can be a list or a string. In the latter case we wrap it so no
+            # special care needs to be taken when fetching the result from the
+            # primitive.
+            if not isinstance(value, list):
+                value = [value]
+
+            on_to_clause_match = _ON_TO_CLAUSE_PATTERN.match(key)
+            on_clause_match = _ON_CLAUSE_PATTERN.match(key)
+            if on_to_clause_match:
+                # We've come across the beginning of a compound statement
+                # with both 'on' and 'to'.
+                finalized_statement = statement
+
+                # First, extract each statement's part of the string
+                on_statement, to_statement = on_to_clause_match.groups()
+
+                # Now create a list of statements, in order
+                compound_statements = [
+                    OnStatement(
+                        on_statement=on_statement,
+                        # body is not used here
+                        body=value,
+                        processor=self,
+                        call_stack=call_stack,
+                    ),
+                    ToStatement(
+                        to_statement=to_statement,
+                        # body is not used here
+                        body=value,
+                        processor=self,
+                        call_stack=call_stack,
+                    ),
+                ]
+
+                # Now our statement is a compound statement
+                statement = CompoundStatement(
+                    statements=compound_statements,
+                    body=value,
+                    processor=self,
+                    call_stack=call_stack,
+                )
+
+            elif on_clause_match:
+                # We've come across the beginning of an 'on' statement.
+                # That means any previous statement we found is complete.
+                finalized_statement = statement
+
+                statement = OnStatement(
+                    on_statement=key,
+                    body=value,
+                    processor=self,
+                    call_stack=call_stack,
+                )
+
+            # TODO remove support for to without on (this statement)
+            elif _TO_CLAUSE_PATTERN.match(key):
+                # We've come across the beginning of a 'to' statement.
+                # That means any previous statement we found is complete.
+                finalized_statement = statement
+
+                statement = ToStatement(
+                    to_statement=key,
+                    body=value,
+                    processor=self,
+                    call_stack=call_stack,
+                )
+
+            elif _TRY_CLAUSE_PATTERN.match(key):
+                # We've come across the beginning of a 'try' statement.
+                # That means any previous statement we found is complete.
+                finalized_statement = statement
+
+                statement = TryStatement(
+                    body=value, processor=self, call_stack=call_stack
+                )
+
+            elif _ELSE_CLAUSE_PATTERN.match(key):
+                _handle_else(statement, value)
+            else:
+                # Since this section is a dictionary, if there are no
+                # markers to indicate the start or change of statement,
+                # the current statement is complete and this section
+                # is a primitive to be collected.
+                finalized_statement = statement
+                statement = None
+
+        return statement, finalized_statement
+
+
+def _handle_else(statement: Optional[Statement], else_body: Optional[Grammar]):
+    """Add else body to current statement.
+
+    :param statement: The currently-active statement. If None it will be
+                      ignored.
+    :param else_body: The body of the else clause to add.
+
+    :raises GrammarSyntaxError: If there isn't a currently-active
+                                     statement.
+    """
+    if statement is None:
+        raise GrammarSyntaxError(
+            "'else' doesn't seem to correspond to an 'on' or 'try'"
+        )
+
+    statement.add_else(else_body)
+
+
+class _StatementCollection:  # pylint: disable=too-few-public-methods
+    """Unique collection of statements to run at a later time."""
+
+    def __init__(self) -> None:
+        self._statements: List[Statement] = []
+
+    def add(self, statement: Optional[Statement]) -> None:
+        """Add new statement to collection.
+
+        :param statement: New statement.
+
+        :raises GrammarSyntaxError: If statement is already in collection.
+        """
+        if not statement:
+            return
+
+        if statement in self._statements:
+            raise GrammarSyntaxError(
+                f"found duplicate {str(statement)!r} statements. These should be merged."
+            )
+
+        self._statements.append(statement)

--- a/craft_grammar/_statement.py
+++ b/craft_grammar/_statement.py
@@ -1,0 +1,170 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017, 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Statement definition for Craft Grammar."""
+
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence, Union
+
+from . import errors
+
+Grammar = Sequence[Union[str, Dict[str, Any]]]
+"""Grammar type."""
+CallStack = List["Statement"]
+"""CallStack type."""
+
+if TYPE_CHECKING:
+    from . import GrammarProcessor
+
+
+class Statement(metaclass=ABCMeta):
+    """Base class for all grammar statements."""
+
+    def __init__(
+        self,
+        *,
+        body: Grammar,
+        processor: "GrammarProcessor",
+        call_stack: Optional[CallStack],
+        check_primitives: bool = False
+    ) -> None:
+        """Create an Statement instance.
+
+        :param body: The body of the clause.
+        :param processor: GrammarProcessor to use for processing
+                        this statement.
+        :param call_stack: call stack leading to this statement.
+        :param arch: the architecture the system is on.
+        :param check_primitives: whether or not the primitives should be
+                                 checked for validity as part of
+                                 evaluating the elses.
+        """
+        if call_stack:
+            self.__call_stack = call_stack
+        else:
+            self.__call_stack = []
+
+        self._body = body
+        self._processor = processor
+        self._check_primitives = check_primitives
+        self._else_bodies: List[Optional[Grammar]] = []
+
+        self.__processed_body: Optional[List[str]] = None
+        self.__processed_else: Optional[List[str]] = None
+
+    def add_else(self, else_body: Optional[Grammar]) -> None:
+        """Add an 'else' clause to the statement.
+
+        :param list else_body: The body of an 'else' clause.
+
+        The 'else' clauses will be processed in the order they are added.
+        """
+        self._else_bodies.append(else_body)
+
+    def process(self) -> List[str]:
+        """Process this statement.
+
+        :return: Primitives as determined by evaluating the statement or its
+                 else clauses.
+        """
+        if self.check():
+            primitives = self._process_body()
+        else:
+            primitives = self._process_else()
+
+        return primitives
+
+    def _process_body(self) -> List[str]:
+        """Process the main body of this statement.
+
+        :return: Primitives as determined by processing the main body.
+        """
+        if self.__processed_body is None:
+            self.__processed_body = self._processor.process(
+                grammar=self._body, call_stack=self._call_stack(include_self=True)
+            )
+
+        return self.__processed_body
+
+    def _process_else(self) -> List[str]:
+        """Process the else clauses of this statement in order.
+
+        :return: Primitives as determined by processing the else clauses.
+        """
+        if self.__processed_else is not None:
+            return self.__processed_else
+
+        self.__processed_else = []
+        for else_body in self._else_bodies:
+            if not else_body:
+                # Handle the 'else fail' case.
+                raise errors.UnsatisfiedStatementError(str(self))
+
+            processed_else = self._processor.process(
+                grammar=else_body, call_stack=self._call_stack()
+            )
+            if processed_else:
+                self.__processed_else = processed_else
+                if not self._check_primitives or self._validate_primitives(
+                    processed_else
+                ):
+                    break
+
+        return self.__processed_else
+
+    def _validate_primitives(self, primitives: Iterable[str]) -> bool:
+        """Ensure that all primitives are valid.
+
+        :param primitives: Iterable container of primitives.
+
+        :return: Whether or not all primitives are valid.
+        :rtype: bool
+        """
+        for primitive in primitives:
+            if not self._processor.checker(primitive):
+                return False
+        return True
+
+    def _call_stack(self, *, include_self=False) -> CallStack:
+        """Return call stack when processing this statement.
+
+        :param bool include_self: Whether or not this statement should be
+                                  included in the stack.
+        """
+        call_stack = self.__call_stack
+        if include_self:
+            call_stack += [self]
+
+        return call_stack
+
+    def __repr__(self):
+        return "{self.__str__()!r}"
+
+    @abstractmethod
+    def check(self) -> bool:
+        """Check if a statement main body should be processed.
+
+        :return: True if main body should be processed, False if elses should
+                 be processed.
+        """
+
+    @abstractmethod
+    def __eq__(self, other) -> bool:
+        """Return if a statement is equal to another."""
+
+    @abstractmethod
+    def __str__(self) -> str:
+        """Return the string representation of the statement."""

--- a/craft_grammar/_to.py
+++ b/craft_grammar/_to.py
@@ -1,0 +1,104 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017, 2018, 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""To Statement for Craft Grammar."""
+
+import re
+from typing import TYPE_CHECKING, Set
+
+from overrides import overrides
+
+from ._statement import CallStack, Grammar, Statement
+from .errors import ToStatementSyntaxError
+
+if TYPE_CHECKING:
+    from ._processor import GrammarProcessor
+
+_SELECTOR_PATTERN = re.compile(r"\Ato\s+([^,\s](?:,?[^,]+)*)\Z")
+_WHITESPACE_PATTERN = re.compile(r"\A.*\s.*\Z")
+
+
+class ToStatement(Statement):
+    """Process a 'to' statement in the grammar."""
+
+    def __init__(
+        self,
+        *,
+        to_statement: str,
+        body: Grammar,
+        processor: "GrammarProcessor",
+        call_stack: CallStack = None,
+    ) -> None:
+        """Create a ToStatement instance.
+
+        :param to_statement: The 'to <selectors>' part of the clause.
+        :param list body: The body of the clause.
+        :param GrammarProcessor process: GrammarProcessor to use for processing
+                                         this statement.
+        :param list call_stack: Call stack leading to this statement.
+        :param target_arch: the architecture the system is to build for.
+        """
+        super().__init__(body=body, processor=processor, call_stack=call_stack)
+
+        self.selectors = _extract_to_clause_selectors(to_statement)
+
+    @overrides
+    def check(self) -> bool:
+        # The only selector currently supported is the target arch. Since
+        # selectors are matched with an AND, not OR, there should only be one
+        # selector.
+        return (len(self.selectors) == 1) and (
+            self._processor.target_arch in self.selectors
+        )
+
+    def __eq__(self, other) -> bool:
+        if type(other) is type(self):
+            return self.selectors == other.selectors
+
+        return False
+
+    def __str__(self) -> str:
+        return f"to {', '.join(sorted(self.selectors))}"
+
+
+def _extract_to_clause_selectors(to_statement: str) -> Set[str]:
+    """Extract the list of selectors within a to clause.
+
+    :param to_statement: The 'to <selector>' part of the 'to' clause.
+
+    :return: Selectors found within the 'to' clause.
+
+    For example:
+    >>> _extract_to_clause_selectors('to amd64,i386') == {'amd64', 'i386'}
+    True
+    """
+    match = _SELECTOR_PATTERN.match(to_statement)
+    if match is None:
+        raise ToStatementSyntaxError(to_statement, message="selectors are missing")
+
+    try:
+        selector_group = match.group(1)
+    except IndexError as index_error:
+        raise ToStatementSyntaxError(to_statement) from index_error
+
+    # This could be part of the _SELECTOR_PATTERN, but that would require us
+    # to provide a very generic error when we can try to be more helpful.
+    if _WHITESPACE_PATTERN.match(selector_group):
+        raise ToStatementSyntaxError(
+            to_statement, message="spaces are not allowed in the selectors"
+        )
+
+    return {selector.strip() for selector in selector_group.split(",")}

--- a/craft_grammar/_try.py
+++ b/craft_grammar/_try.py
@@ -1,0 +1,72 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017, 2018, 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Try Statement for Craft Grammar."""
+
+from typing import TYPE_CHECKING
+
+from overrides import overrides
+
+from ._statement import CallStack, Grammar, Statement
+
+# Don't use circular imports unless type checking
+if TYPE_CHECKING:
+    from ._processor import GrammarProcessor
+
+
+class TryStatement(Statement):
+    """Process a 'try' statement in the grammar.
+
+    For example:
+    >>> from snapcraft_legacy import ProjectOptions
+    >>> from ._processor import GrammarProcessor
+    >>> def checker(primitive):
+    ...     return 'invalid' not in primitive
+    >>> options = ProjectOptions()
+    >>> processor = GrammarProcessor(None, options, checker)
+    >>> clause = TryStatement(body=['invalid'], processor=processor)
+    >>> clause.add_else(['valid'])
+    >>> clause.process()
+    {'valid'}
+    """
+
+    def __init__(
+        self,
+        *,
+        body: Grammar,
+        processor: "GrammarProcessor",
+        call_stack: CallStack = None
+    ) -> None:
+        """Create a TryStatement instance.
+
+        :param body: The body of the clause.
+        :param processor: GrammarProcessor to use for processing
+                                         this statement.
+        :param call_stack: Call stack leading to this statement.
+        """
+        super().__init__(
+            body=body, processor=processor, call_stack=call_stack, check_primitives=True
+        )
+
+    @overrides
+    def check(self) -> bool:
+        return self._validate_primitives(self._process_body())
+
+    def __eq__(self, other) -> bool:
+        return False
+
+    def __str__(self) -> str:
+        return "try"

--- a/craft_grammar/errors.py
+++ b/craft_grammar/errors.py
@@ -16,6 +16,8 @@
 
 """Errors for Craft Grammar."""
 
+from typing import Optional
+
 
 class CraftGrammarError(Exception):
     """Base class error for craft-grammar."""
@@ -31,7 +33,7 @@ class GrammarSyntaxError(CraftGrammarError):
 class OnStatementSyntaxError(GrammarSyntaxError):
     """Error raised on on statement syntax errors."""
 
-    def __init__(self, on_statement, *, message=None):
+    def __init__(self, on_statement: str, *, message: Optional[str] = None):
         components = [f"{on_statement!r} is not a valid 'on' clause"]
         if message:
             components.append(message)
@@ -41,7 +43,7 @@ class OnStatementSyntaxError(GrammarSyntaxError):
 class ToStatementSyntaxError(GrammarSyntaxError):
     """Error raised on to statement syntax errors."""
 
-    def __init__(self, to_statement, *, message=None):
+    def __init__(self, to_statement: str, *, message: Optional[str] = None):
         components = [f"{to_statement!r} is not a valid 'to' clause"]
         if message:
             components.append(message)
@@ -51,5 +53,5 @@ class ToStatementSyntaxError(GrammarSyntaxError):
 class UnsatisfiedStatementError(CraftGrammarError):
     """Error raised when a statement cannot be satisfied."""
 
-    def __init__(self, statement):
+    def __init__(self, statement: str):
         super().__init__(f"Unable to satisfy {statement!r}, failure forced.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,8 @@ python_requires = >= 3.8
 include_package_data = True
 packages = find:
 zip_safe = False
+install_requires =
+    overrides
 
 [options.package_data]
 craft_grammar = py.typed
@@ -117,11 +119,3 @@ ignore = D105, D107, D203, D213, D215
 test = pytest
 
 [tool:pytest]
-
-[isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 88

--- a/tests/unit/test_compound.py
+++ b/tests/unit/test_compound.py
@@ -1,0 +1,239 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import re
+
+import pytest
+
+from craft_grammar import (
+    CompoundStatement,
+    GrammarProcessor,
+    OnStatement,
+    ToStatement,
+    errors,
+)
+
+scenarios = [
+    # on amd64
+    {
+        "on_arch": "on amd64",
+        "to_arch": "to armhf",
+        "body": ["foo"],
+        "else_bodies": [],
+        "arch": "amd64",
+        "expected_packages": ["foo"],
+    },
+    # on i386
+    {
+        "on_arch": "on amd64",
+        "to_arch": "to armhf",
+        "body": ["foo"],
+        "else_bodies": [],
+        "arch": "i386",
+        "expected_packages": [],
+    },
+    # ignored else
+    {
+        "on_arch": "on amd64",
+        "to_arch": "to armhf",
+        "body": ["foo"],
+        "else_bodies": [["bar"]],
+        "arch": "amd64",
+        "expected_packages": ["foo"],
+    },
+    # used else
+    {
+        "on_arch": "on amd64",
+        "to_arch": "to i386",
+        "body": ["foo"],
+        "else_bodies": [["bar"]],
+        "arch": "i386",
+        "expected_packages": ["bar"],
+    },
+    # third else ignored
+    {
+        "on_arch": "on amd64",
+        "to_arch": "to i386",
+        "body": ["foo"],
+        "else_bodies": [["bar"], ["baz"]],
+        "arch": "i386",
+        "expected_packages": ["bar"],
+    },
+    # third else followed
+    {
+        "on_arch": "on amd64",
+        "to_arch": "to i386",
+        "body": ["foo"],
+        "else_bodies": [[{"on armhf": ["bar"]}], ["baz"]],
+        "arch": "i386",
+        "expected_packages": ["baz"],
+    },
+    # nested amd64
+    {
+        "on_arch": "on amd64",
+        "to_arch": "to armhf",
+        "body": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}],
+        "else_bodies": [],
+        "arch": "amd64",
+        "expected_packages": ["foo"],
+    },
+    # nested i386
+    {
+        "on_arch": "on i386",
+        "to_arch": "to armhf",
+        "body": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}],
+        "else_bodies": [],
+        "arch": "i386",
+        "expected_packages": ["bar"],
+    },
+    # nested body ignored else
+    {
+        "on_arch": "on amd64",
+        "to_arch": "to armhf",
+        "body": [{"on amd64": ["foo"]}, {"else": ["bar"]}],
+        "else_bodies": [],
+        "arch": "amd64",
+        "expected_packages": ["foo"],
+    },
+    # nested body used else
+    {
+        "on_arch": "on i386",
+        "to_arch": "to armhf",
+        "body": [{"on amd64": ["foo"]}, {"else": ["bar"]}],
+        "else_bodies": [],
+        "arch": "i386",
+        "expected_packages": ["bar"],
+    },
+    # nested else ignored else
+    {
+        "on_arch": "on armhf",
+        "to_arch": "to i386",
+        "body": ["foo"],
+        "else_bodies": [[{"on amd64": ["bar"]}, {"else": ["baz"]}]],
+        "arch": "amd64",
+        "expected_packages": ["bar"],
+    },
+    # nested else used else",
+    {
+        "on_arch": "on armhf",
+        "to_arch": "to i386",
+        "body": ["foo"],
+        "else_bodies": [[{"on amd64": ["bar"]}, {"else": ["baz"]}]],
+        "arch": "i386",
+        "expected_packages": ["baz"],
+    },
+    # "with hyphen
+    {
+        "on_arch": "on other-arch",
+        "to_arch": "to yet-another-arch",
+        "body": ["foo"],
+        "else_bodies": [],
+        "arch": "amd64",
+        "expected_packages": [],
+    },
+    # multiple selectors
+    {
+        "on_arch": "on amd64,i386",
+        "to_arch": "to armhf,arm64",
+        "body": ["foo"],
+        "else_bodies": [],
+        "arch": "amd64",
+        "expected_packages": [],
+    },
+]
+
+
+@pytest.mark.parametrize("scenario", scenarios)
+def test_compound_statement(scenario):
+
+    processor = GrammarProcessor(
+        arch=scenario["arch"],
+        target_arch="armhf",
+        checker=lambda x: True,
+    )
+    statements = [
+        OnStatement(
+            on_statement=scenario["on_arch"], body=scenario["body"], processor=processor
+        ),
+        ToStatement(
+            to_statement=scenario["to_arch"], body=scenario["body"], processor=processor
+        ),
+    ]
+    statement = CompoundStatement(
+        statements=statements, body=scenario["body"], processor=processor
+    )
+
+    for else_body in scenario["else_bodies"]:
+        statement.add_else(else_body)
+
+    assert statement.process() == scenario["expected_packages"]
+
+
+error_scenarios = [
+    # spaces in on selectors
+    {
+        "on_arch": "on amd64, ubuntu",
+        "to_arch": "to i386",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": errors.OnStatementSyntaxError,
+        "expected_message": ".*not a valid 'on' clause.*spaces are not allowed in the "
+        "selectors.*",
+    },
+    # spaces in to selectors
+    {
+        "on_arch": "on amd64,ubuntu",
+        "to_arch": "to i386, armhf",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": errors.ToStatementSyntaxError,
+        "expected_message": ".*not a valid 'to' clause.*spaces are not allowed in the "
+        "selectors.*",
+    },
+]
+
+
+@pytest.mark.parametrize("scenario", error_scenarios)
+def test_errors(scenario):
+    with pytest.raises(scenario["expected_exception"]) as grammar_error:
+        processor = GrammarProcessor(
+            arch="amd64",
+            target_arch="armhf",
+            checker=lambda x: "invalid" not in x,
+        )
+        statements = [
+            OnStatement(
+                on_statement=scenario["on_arch"],
+                body=scenario["body"],
+                processor=processor,
+            ),
+            ToStatement(
+                to_statement=scenario["to_arch"],
+                body=scenario["body"],
+                processor=processor,
+            ),
+        ]
+        statement = CompoundStatement(
+            statements=statements, body=scenario["body"], processor=processor
+        )
+
+        for else_body in scenario["else_bodies"]:
+            statement.add_else(else_body)
+
+        statement.process()
+
+    assert re.match(scenario["expected_message"], str(grammar_error.value))

--- a/tests/unit/test_on.py
+++ b/tests/unit/test_on.py
@@ -1,0 +1,151 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import re
+
+import pytest
+
+from craft_grammar import GrammarProcessor, OnStatement, errors
+
+
+def test_on():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="amd64", target_arch="amd64"
+    )
+
+    clause = OnStatement(on_statement="on amd64", body=["foo"], processor=processor)
+    assert clause.process() == ["foo"]
+
+
+def test_on_else():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="amd64", target_arch="amd64"
+    )
+
+    clause = OnStatement(on_statement="on arm64", body=["foo"], processor=processor)
+    clause.add_else(["bar"])
+    assert clause.process() == ["bar"]
+
+
+def test_on_else_fail():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="amd64", target_arch="amd64"
+    )
+
+    clause = OnStatement(on_statement="on arm64", body=["foo"], processor=processor)
+    clause.add_else(None)
+    with pytest.raises(errors.UnsatisfiedStatementError):
+        clause.process()
+
+
+def test_on_nested_else_with_valid_on_else():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="arm64", target_arch="amd64"
+    )
+
+    clause = OnStatement(on_statement="on amd64", body=["foo"], processor=processor)
+    clause.add_else([{"on arm64": ["bar"]}])
+    clause.add_else(["baz"])
+    assert clause.process() == ["bar"]
+
+
+def test_on_nested_else_with_on_but_valid_else():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="i386", target_arch="i386"
+    )
+
+    clause = OnStatement(on_statement="on amd64", body=["foo"], processor=processor)
+    clause.add_else([{"on riscv64": ["bar"]}])
+    clause.add_else(["baz"])
+    assert clause.process() == ["baz"]
+
+
+def test_on_missing():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="amd64", target_arch="amd64"
+    )
+
+    with pytest.raises(errors.OnStatementSyntaxError):
+        OnStatement(
+            on_statement="to amd64",
+            body=["foo"],
+            processor=processor,
+        )
+
+
+error_scenarios = [
+    # spaces in selectors
+    {
+        "on_arch": "on amd64, ubuntu",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'on' clause.*spaces are not allowed in the selectors.*",
+    },
+    # beginning with comma
+    {
+        "on_arch": "on ,amd64",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'on' clause",
+    },
+    # ending with comma
+    {
+        "on_arch": "on amd64,",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'on' clause",
+    },
+    # multiple commas
+    {
+        "on_arch": "on amd64,,ubuntu",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'on' clause",
+    },
+    # invalid selector format
+    {
+        "on_arch": "on",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'on' clause.*selectors are missing",
+    },
+    # not even close
+    {
+        "on_arch": "im-invalid",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'on' clause",
+    },
+]
+
+
+@pytest.mark.parametrize("scenario", error_scenarios)
+def test_errors(scenario):
+    with pytest.raises(errors.OnStatementSyntaxError) as syntax_error:
+        processor = GrammarProcessor(
+            arch="amd64", target_arch="amd64", checker=lambda x: "invalid" not in x
+        )
+        statement = OnStatement(
+            on_statement=scenario["on_arch"], body=scenario["body"], processor=processor
+        )
+
+        for else_body in scenario["else_bodies"]:
+            statement.add_else(else_body)
+
+        statement.process()
+
+    assert re.match(scenario["expected_exception"], str(syntax_error.value))

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -1,0 +1,358 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import re
+
+import pytest
+
+from craft_grammar import GrammarProcessor, ToStatement, errors
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        [{"on amd64,i386": ["foo"]}, {"on amd64,i386": ["bar"]}],
+        [{"on amd64,i386": ["foo"]}, {"on i386,amd64": ["bar"]}],
+    ],
+)
+def test_duplicates(entry):
+    """Test that multiple identical selector sets is an error."""
+
+    processor = GrammarProcessor(
+        arch="amd64", target_arch="amd64", checker=lambda x: True
+    )
+    with pytest.raises(errors.GrammarSyntaxError) as error:
+        processor.process(grammar=entry)
+
+    expected = (
+        "Invalid grammar syntax: found duplicate 'on amd64,i386' "
+        "statements. These should be merged."
+    )
+    assert expected in str(error.value)
+
+
+scenarios = [
+    # unconditional
+    {
+        "grammar_entry": ["foo", "bar"],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": ["foo", "bar"],
+    },
+    # unconditional dict
+    {
+        "grammar_entry": [{"foo": "bar"}],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": [{"foo": "bar"}],
+    },
+    # unconditional multi-dict
+    {
+        "grammar_entry": [{"foo": "bar"}, {"foo2": "bar2"}],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": [{"foo": "bar"}, {"foo2": "bar2"}],
+    },
+    # mixed including
+    {
+        "grammar_entry": ["foo", {"on i386": ["bar"]}],
+        "arch": "i386",
+        "target_arch": "i386",
+        "expected_results": ["foo", "bar"],
+    },
+    # mixed excluding
+    {
+        "grammar_entry": ["foo", {"on i386": ["bar"]}],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": ["foo"],
+    },
+    # on amd64
+    {
+        "grammar_entry": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": ["foo"],
+    },
+    # on i386
+    {
+        "grammar_entry": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}],
+        "arch": "i386",
+        "target_arch": "i386",
+        "expected_results": ["bar"],
+    },
+    # ignored else
+    {
+        "grammar_entry": [{"on amd64": ["foo"]}, {"else": ["bar"]}],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": ["foo"],
+    },
+    # used else
+    {
+        "grammar_entry": [{"on amd64": ["foo"]}, {"else": ["bar"]}],
+        "arch": "i386",
+        "target_arch": "i386",
+        "expected_results": ["bar"],
+    },
+    # nested amd64
+    {
+        "grammar_entry": [{"on amd64": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}]}],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": ["foo"],
+    },
+    # nested amd64 dict
+    {
+        "grammar_entry": [
+            {"on amd64": [{"on amd64": [{"foo": "bar"}]}, {"on i386": ["bar"]}]}
+        ],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": [{"foo": "bar"}],
+    },
+    # nested i386
+    {
+        "grammar_entry": [{"on i386": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}]}],
+        "arch": "i386",
+        "target_arch": "i386",
+        "expected_results": ["bar"],
+    },
+    # nested ignored else
+    {
+        "grammar_entry": [{"on amd64": [{"on amd64": ["foo"]}, {"else": ["bar"]}]}],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": ["foo"],
+    },
+    # nested used else
+    {
+        "grammar_entry": [{"on i386": [{"on amd64": ["foo"]}, {"else": ["bar"]}]}],
+        "arch": "i386",
+        "target_arch": "amd64",
+        "expected_results": ["bar"],
+    },
+    # try
+    {
+        "grammar_entry": [{"try": ["valid"]}],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": ["valid"],
+    },
+    # try else
+    {
+        "grammar_entry": [{"try": ["invalid"]}, {"else": ["valid"]}],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": ["valid"],
+    },
+    # nested try
+    {
+        "grammar_entry": [{"on amd64": [{"try": ["foo"]}, {"else": ["bar"]}]}],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": ["foo"],
+    },
+    # nested try else
+    {
+        "grammar_entry": [{"on i386": [{"try": ["invalid"]}, {"else": ["bar"]}]}],
+        "arch": "i386",
+        "target_arch": "i386",
+        "expected_results": ["bar"],
+    },
+    # optional
+    {
+        "grammar_entry": ["foo", {"try": ["invalid"]}],
+        "arch": "i386",
+        "target_arch": "i386",
+        "expected_results": ["foo"],
+    },
+    # multi
+    {
+        "grammar_entry": [
+            "foo",
+            {"on amd64": ["foo2"]},
+            {"on amd64 to arm64": ["foo3"]},
+        ],
+        "arch": "amd64",
+        "target_arch": "i386",
+        "expected_results": ["foo", "foo2"],
+    },
+    # multi-ordering
+    {
+        "grammar_entry": [
+            "foo",
+            {"on amd64": ["on-foo"]},
+            "after-on",
+            {"on amd64 to i386": ["on-to-foo"]},
+            {"on amd64 to arm64": ["no-show"]},
+            "n-1",
+            "n",
+        ],
+        "arch": "amd64",
+        "target_arch": "i386",
+        "expected_results": [
+            "foo",
+            "on-foo",
+            "after-on",
+            "on-to-foo",
+            "n-1",
+            "n",
+        ],
+    },
+    # complex nested dicts
+    {
+        "grammar_entry": [
+            {"yes1": "yes1"},
+            {
+                "on amd64": [
+                    {"yes2": "yes2"},
+                    {"on amd64": [{"yes3": "yes3"}]},
+                    {"yes4": "yes4"},
+                    {"on i386": [{"no1": "no1"}]},
+                    {"else": [{"yes5": "yes5"}]},
+                    {"yes6": "yes6"},
+                ],
+            },
+            {"else": [{"no2": "no2"}]},
+            {"yes7": "yes7"},
+            {"on i386": [{"no3": "no3"}]},
+            {"else": [{"yes8": "yes8"}]},
+            {"yes9": "yes9"},
+        ],
+        "arch": "amd64",
+        "target_arch": "amd64",
+        "expected_results": [
+            {"yes1": "yes1"},
+            {"yes2": "yes2"},
+            {"yes3": "yes3"},
+            {"yes4": "yes4"},
+            {"yes5": "yes5"},
+            {"yes6": "yes6"},
+            {"yes7": "yes7"},
+            {"yes8": "yes8"},
+            {"yes9": "yes9"},
+        ],
+    },
+]
+
+
+@pytest.mark.parametrize("scenario", scenarios)
+def test_basic_grammar(scenario):
+    processor = GrammarProcessor(
+        arch=scenario["arch"],
+        target_arch=scenario["target_arch"],
+        checker=lambda x: "invalid" not in x,
+    )
+    assert (
+        processor.process(grammar=scenario["grammar_entry"])
+        == scenario["expected_results"]
+    )
+
+
+transformer_scenarios = [
+    # unconditional
+    {
+        "grammar_entry": ["foo", "bar"],
+        "arch": "amd64",
+        "expected_results": ["foo", "bar"],
+    },
+    # mixed including
+    {
+        "grammar_entry": ["foo", {"on i386": ["bar"]}],
+        "arch": "i386",
+        "expected_results": ["foo", "bar"],
+    },
+    # mixed excluding
+    {
+        "grammar_entry": ["foo", {"on i386": ["bar"]}],
+        "arch": "amd64",
+        "expected_results": ["foo"],
+    },
+    # to
+    {
+        "grammar_entry": [{"to i386": ["foo"]}],
+        "arch": "amd64",
+        "expected_results": ["foo:i386"],
+    },
+    # transform applies to nested
+    {
+        "grammar_entry": [{"to i386": [{"on amd64": ["foo"]}]}],
+        "arch": "amd64",
+        "expected_results": ["foo:i386"],
+    },
+    # not to
+    {
+        "grammar_entry": [{"to amd64": ["foo"]}, {"else": ["bar"]}],
+        "arch": "amd64",
+        "expected_results": ["bar"],
+    },
+]
+
+
+@pytest.mark.parametrize("scenario", transformer_scenarios)
+def test_grammar_with_transformer(scenario):
+    # Transform all 'to' statements to include arch
+    def transformer(call_stack, package_name, target_arch):
+        if any(isinstance(s, ToStatement) for s in call_stack):
+            if ":" not in package_name:
+                package_name = f"{package_name}:{target_arch}"
+
+        return package_name
+
+    processor = GrammarProcessor(
+        arch=scenario["arch"],
+        target_arch="i386",
+        checker=lambda x: True,
+        transformer=transformer,
+    )
+
+    assert (
+        processor.process(grammar=scenario["grammar_entry"])
+        == scenario["expected_results"]
+    )
+
+
+error_scenarios = [
+    # unmatched else
+    {
+        "grammar_entry": [{"else": ["foo"]}],
+        "expected_exception": ".*'else' doesn't seem to correspond.*",
+    },
+    # unmatched else fail
+    {
+        "grammar_entry": ["else fail"],
+        "expected_exception": ".*'else' doesn't seem to correspond.*",
+    },
+    # unexpected type
+    {
+        "grammar_entry": [5],
+        "expected_exception": ".*expected grammar section.*but got.*",
+    },
+]
+
+
+@pytest.mark.parametrize("scenario", error_scenarios)
+def test_invalid_grammar(scenario):
+    processor = GrammarProcessor(
+        arch="amd64", target_arch="amd64", checker=lambda x: True
+    )
+
+    with pytest.raises(errors.GrammarSyntaxError) as error:
+        processor.process(grammar=scenario["grammar_entry"])
+
+    assert re.match(scenario["expected_exception"], str(error.value))

--- a/tests/unit/test_to.py
+++ b/tests/unit/test_to.py
@@ -1,0 +1,151 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import re
+
+import pytest
+
+from craft_grammar import GrammarProcessor, ToStatement, errors
+
+
+def test_on():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="amd64", target_arch="amd64"
+    )
+
+    clause = ToStatement(to_statement="to amd64", body=["foo"], processor=processor)
+    assert clause.process() == ["foo"]
+
+
+def test_on_else():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="amd64", target_arch="amd64"
+    )
+
+    clause = ToStatement(to_statement="to arm64", body=["foo"], processor=processor)
+    clause.add_else(["bar"])
+    assert clause.process() == ["bar"]
+
+
+def test_on_else_fail():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="amd64", target_arch="amd64"
+    )
+
+    clause = ToStatement(to_statement="to arm64", body=["foo"], processor=processor)
+    clause.add_else(None)
+    with pytest.raises(errors.UnsatisfiedStatementError):
+        clause.process()
+
+
+def test_on_nested_else_with_valid_on_else():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="arm64", target_arch="arm64"
+    )
+
+    clause = ToStatement(to_statement="to amd64", body=["foo"], processor=processor)
+    clause.add_else([{"to arm64": ["bar"]}])
+    clause.add_else(["baz"])
+    assert clause.process() == ["bar"]
+
+
+def test_on_nested_else_with_on_but_valid_else():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="i386", target_arch="i386"
+    )
+
+    clause = ToStatement(to_statement="to amd64", body=["foo"], processor=processor)
+    clause.add_else([{"to riscv64": ["bar"]}])
+    clause.add_else(["baz"])
+    assert clause.process() == ["baz"]
+
+
+def test_on_missing():
+    processor = GrammarProcessor(
+        checker=lambda x: True, arch="amd64", target_arch="amd64"
+    )
+
+    with pytest.raises(errors.ToStatementSyntaxError):
+        ToStatement(
+            to_statement="on amd64",
+            body=["foo"],
+            processor=processor,
+        )
+
+
+error_scenarios = [
+    # spaces in selectors
+    {
+        "to_arch": "to amd64, ubuntu",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'to' clause.*spaces are not allowed in the selectors.*",
+    },
+    # beginning with comma
+    {
+        "to_arch": "to ,amd64",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'to' clause",
+    },
+    # ending with comma
+    {
+        "to_arch": "to amd64,",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'to' clause",
+    },
+    # multiple commas
+    {
+        "to_arch": "to amd64,,ubuntu",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'to' clause",
+    },
+    # invalid selector format
+    {
+        "to_arch": "on",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'to' clause.*selectors are missing",
+    },
+    # not even close
+    {
+        "to_arch": "im-invalid",
+        "body": ["foo"],
+        "else_bodies": [],
+        "expected_exception": ".*not a valid 'to' clause",
+    },
+]
+
+
+@pytest.mark.parametrize("scenario", error_scenarios)
+def test_errors(scenario):
+    with pytest.raises(errors.ToStatementSyntaxError) as syntax_error:
+        processor = GrammarProcessor(
+            arch="amd64", target_arch="amd64", checker=lambda x: "invalid" not in x
+        )
+        statement = ToStatement(
+            to_statement=scenario["to_arch"], body=scenario["body"], processor=processor
+        )
+
+        for else_body in scenario["else_bodies"]:
+            statement.add_else(else_body)
+
+        statement.process()
+
+    assert re.match(scenario["expected_exception"], str(syntax_error.value))

--- a/tests/unit/test_try.py
+++ b/tests/unit/test_try.py
@@ -1,0 +1,120 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import pytest
+
+from craft_grammar import GrammarProcessor, TryStatement, errors
+
+scenarios = [
+    # followed body
+    {
+        "body": ["foo", "bar"],
+        "else_bodies": [],
+        "expected_packages": ["foo", "bar"],
+    },
+    # followed else
+    {
+        "body": ["invalid"],
+        "else_bodies": [["valid"]],
+        "expected_packages": ["valid"],
+    },
+    # optional without else
+    {"body": ["invalid"], "else_bodies": [], "expected_packages": []},
+    # followed chained else
+    {
+        "body": ["invalid1"],
+        "else_bodies": [["invalid2"], ["finally-valid"]],
+        "expected_packages": ["finally-valid"],
+    },
+    # nested body followed body
+    {
+        "body": [{"try": ["foo"]}, {"else": ["bar"]}],
+        "else_bodies": [],
+        "expected_packages": ["foo"],
+    },
+    # nested body followed else
+    {
+        "body": [{"try": ["invalid"]}, {"else": ["bar"]}],
+        "else_bodies": [],
+        "expected_packages": ["bar"],
+    },
+    # nested else followed body
+    {
+        "body": ["invalid"],
+        "else_bodies": [[{"try": ["foo"]}, {"else": ["bar"]}]],
+        "expected_packages": ["foo"],
+    },
+    # nested else followed else
+    {
+        "body": ["invalid"],
+        "else_bodies": [[{"try": ["invalid"]}, {"else": ["bar"]}]],
+        "expected_packages": ["bar"],
+    },
+    # multiple elses
+    {
+        "body": ["invalid1"],
+        "else_bodies": [["invalid2"], ["valid"]],
+        "expected_packages": ["valid"],
+    },
+    # multiple elses all invalid
+    {
+        "body": ["invalid1"],
+        "else_bodies": [["invalid2"], ["invalid3"]],
+        "expected_packages": ["invalid3"],
+    },
+]
+
+
+@pytest.mark.parametrize("scenario", scenarios)
+def test_try_statement_grammar(scenario):
+    processor = GrammarProcessor(
+        arch="amd64", target_arch="amd64", checker=lambda x: "invalid" not in x
+    )
+    statement = TryStatement(body=scenario["body"], processor=processor)
+
+    for else_body in scenario["else_bodies"]:
+        statement.add_else(else_body)
+
+    assert statement.process() == scenario["expected_packages"]
+
+
+def test_invalid_try_with_no_else():
+    def checker(primitive) -> bool:
+        return primitive == "valid-else"
+
+    processor = GrammarProcessor(checker=checker, arch="amd64", target_arch="amd64")
+    clause = TryStatement(
+        body=["invalid-try"],
+        processor=processor,
+    )
+
+    assert clause.process() == []
+
+
+def test_invalid_try_with_else_fail():
+    def checker(primitive) -> bool:
+        return primitive == "valid-else"
+
+    processor = GrammarProcessor(checker=checker, arch="amd64", target_arch="amd64")
+    clause = TryStatement(
+        body=["invalid-try"],
+        processor=processor,
+    )
+    clause.add_else(None)
+
+    with pytest.raises(errors.UnsatisfiedStatementError):
+        clause.process()


### PR DESCRIPTION
Noticeable changes:

- updated to support latest pylint, mypy, pyright and black
- types for error parameters
- grammarProcessor no longer takes a grammar entry, it is now mandatory to pass
  to .process and it is a mandatory parameter for it
- removed coupling with Snapcraft's ProjectOptions, and require arch and
  target_arch for GrammarProcessor
- transformer method signature changed to require target_arch instead of
  ProjectOptions
- most parameters for methods now require kwargs

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
