### PR TITLE
models: create grammar-aware pydantic models (CRAFT-856)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -40,6 +40,7 @@ limit-inference-results=100
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
 load-plugins=pylint_fixme_info,
+             pylint_pydantic,
              pylint_pytest
 
 # Pickle collected data for later comparisons.
@@ -151,6 +152,7 @@ disable=print-statement,
         line-too-long,
         fixme,
         fixme-info,
+        too-few-public-methods,
         duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test-pydocstyle:
 .PHONY: test-pylint
 test-pylint:
 	pylint craft_grammar
-	pylint tests --disable=missing-module-docstring,missing-function-docstring,redefined-outer-name
+	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,redefined-outer-name
 
 .PHONY: test-pyright
 test-pyright:

--- a/craft_grammar/_compound.py
+++ b/craft_grammar/_compound.py
@@ -16,7 +16,7 @@
 
 """Compound Statement for Craft Grammar."""
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 from overrides import overrides
 
@@ -35,7 +35,7 @@ class CompoundStatement(Statement):
         statements: List[Statement],
         body: Grammar,
         processor: "GrammarProcessor",
-        call_stack: CallStack = None,
+        call_stack: Optional[CallStack] = None,
     ) -> None:
         """Create an CompoundStatement instance.
 

--- a/craft_grammar/_on.py
+++ b/craft_grammar/_on.py
@@ -17,7 +17,7 @@
 """On Statement for Craft Grammar."""
 
 import re
-from typing import TYPE_CHECKING, Set
+from typing import TYPE_CHECKING, Optional, Set
 
 from overrides import overrides
 
@@ -40,7 +40,7 @@ class OnStatement(Statement):
         on_statement: str,
         body: Grammar,
         processor: "GrammarProcessor",
-        call_stack: CallStack = None,
+        call_stack: Optional[CallStack] = None,
     ) -> None:
         """Create an OnStatement instance.
 

--- a/craft_grammar/_processor.py
+++ b/craft_grammar/_processor.py
@@ -43,7 +43,7 @@ class GrammarProcessor:  # pylint: disable=too-few-public-methods
         checker: Callable[[Any], bool],
         arch: str,
         target_arch: str,
-        transformer: Callable[[List[Statement], str, str], str] = None,
+        transformer: Optional[Callable[[List[Statement], str, str], str]] = None,
     ) -> None:
         """Create a new GrammarProcessor.
 
@@ -65,7 +65,9 @@ class GrammarProcessor:  # pylint: disable=too-few-public-methods
             # By default, no transformation
             self._transformer = lambda s, p, o: p
 
-    def process(self, *, grammar: Grammar, call_stack: CallStack = None) -> List[Any]:
+    def process(
+        self, *, grammar: Grammar, call_stack: Optional[CallStack] = None
+    ) -> List[Any]:
         """Process grammar and extract desired primitives.
 
         :param grammar: Unprocessed grammar.

--- a/craft_grammar/_to.py
+++ b/craft_grammar/_to.py
@@ -17,7 +17,7 @@
 """To Statement for Craft Grammar."""
 
 import re
-from typing import TYPE_CHECKING, Set
+from typing import TYPE_CHECKING, Optional, Set
 
 from overrides import overrides
 
@@ -40,7 +40,7 @@ class ToStatement(Statement):
         to_statement: str,
         body: Grammar,
         processor: "GrammarProcessor",
-        call_stack: CallStack = None,
+        call_stack: Optional[CallStack] = None,
     ) -> None:
         """Create a ToStatement instance.
 

--- a/craft_grammar/_try.py
+++ b/craft_grammar/_try.py
@@ -16,7 +16,7 @@
 
 """Try Statement for Craft Grammar."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from overrides import overrides
 
@@ -48,7 +48,7 @@ class TryStatement(Statement):
         *,
         body: Grammar,
         processor: "GrammarProcessor",
-        call_stack: CallStack = None
+        call_stack: Optional[CallStack] = None
     ) -> None:
         """Create a TryStatement instance.
 

--- a/craft_grammar/models.py
+++ b/craft_grammar/models.py
@@ -1,0 +1,116 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Pydantic models for grammar."""
+
+import re
+from typing import Any, Dict, List, Union
+
+from overrides import overrides
+
+
+class _GrammarBase:
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, entry):
+        """Transform 'on' and 'to' field names."""
+        if not isinstance(entry, dict):
+            return entry
+
+        new_entry = {}
+        for key, value in entry.items():
+            # Do, or do not. There is no try.
+            if key == "try":
+                raise ValueError(
+                    "'try' was removed from grammar, use 'on <arch>' instead"
+                )
+
+            if re.match(r"^on\s+.+", key):
+                new_entry["on"] = cls.validate(value)
+            elif re.match(r"^to\s+.+", key):
+                new_entry["to"] = cls.validate(value)
+            elif key == "else fail":
+                if value:
+                    raise ValueError("'else fail' must have no arguments")
+                new_entry[key] = None
+            elif key == "else":
+                new_entry[key] = cls.validate(value)
+            else:
+                raise ValueError(f"invalid grammar key {key!r}")
+
+        return new_entry
+
+
+_GrammarType = Dict[str, Any]
+
+
+# Public types for grammar-enabled attributes
+
+
+class GrammarStr(_GrammarBase):
+    """Grammar-enabled string field."""
+
+    __root__: Union[str, _GrammarType]
+
+    @classmethod
+    @overrides
+    def validate(cls, entry):
+        if isinstance(entry, dict):
+            return super().validate(entry)
+
+        if isinstance(entry, str):
+            return entry
+
+        raise TypeError(f"value must be a string: {entry!r}")
+
+
+class GrammarStrList(_GrammarBase):
+    """Grammar-enabled list of strings field."""
+
+    __root__: Union[List[str], _GrammarType]
+
+    @classmethod
+    @overrides
+    def validate(cls, entry):
+        if isinstance(entry, dict):
+            return super().validate(entry)
+
+        if isinstance(entry, list) and all((isinstance(x, str) for x in entry)):
+            return entry
+
+        raise TypeError(f"value must be a list of string: {entry!r}")
+
+
+class GrammarSingleEntryDictList(_GrammarBase):
+    """Grammar-enabled list of dictionaries field."""
+
+    __root__: Union[List[Dict[str, Any]], _GrammarType]
+
+    @classmethod
+    @overrides
+    def validate(cls, entry):
+        if isinstance(entry, dict):
+            return super().validate(entry)
+
+        if isinstance(entry, list) and all(
+            ((isinstance(x, dict) and len(x) == 1) for x in entry)
+        ):
+            return entry
+
+        raise TypeError(f"value must be a list of single-entry dictionaries: {entry!r}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,15 +50,19 @@ test =
     flake8
     isort
     mypy
+    pydantic
     pydocstyle
     pylint
     pylint-fixme-info
+    pylint-pydantic
     pylint-pytest
     pytest
     pytest-mock
+    PyYAML
     tox
     types-requests
     types-setuptools
+    types-PyYAML
 dev =
     autoflake
     %(release)s

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,293 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import textwrap
+from unittest.mock import ANY
+
+import pydantic
+import pytest
+import yaml
+
+from craft_grammar.models import GrammarSingleEntryDictList, GrammarStr, GrammarStrList
+
+
+class ValidationTest(pydantic.BaseModel):
+    """A test model containing all types of grammar-aware types."""
+
+    control: str
+    grammar_str: GrammarStr
+    grammar_strlist: GrammarStrList
+    grammar_single_entry_dictlist: GrammarSingleEntryDictList
+
+
+def test_validate_grammar_trivial():
+    data = yaml.safe_load(
+        textwrap.dedent(
+            """
+            control: a string
+            grammar_str: another string
+            grammar_strlist:
+              - a
+              - string
+              - list
+            grammar_single_entry_dictlist:
+              - key: value
+              - other_key: other_value
+            """
+        )
+    )
+
+    v = ValidationTest(**data)
+    assert v.control == "a string"
+    assert v.grammar_str == "another string"
+    assert v.grammar_strlist == ["a", "string", "list"]
+    assert v.grammar_single_entry_dictlist == [
+        {"key": "value"},
+        {"other_key": "other_value"},
+    ]
+
+
+def test_validate_grammar_simple():
+    data = yaml.safe_load(
+        textwrap.dedent(
+            """
+            control: a string
+            grammar_str:
+              on amd64: another string
+              else: something different
+            grammar_strlist:
+              to amd64, arm64:
+                - a
+                - string
+                - list
+            grammar_single_entry_dictlist:
+              on arch:
+                 - key: value
+                 - other_key: other_value
+              else fail:
+            """
+        )
+    )
+
+    v = ValidationTest(**data)
+    assert v.control == "a string"
+    assert v.grammar_str == {
+        "on": "another string",
+        "else": "something different",
+    }
+    assert v.grammar_strlist == {
+        "to": ["a", "string", "list"],
+    }
+    assert v.grammar_single_entry_dictlist == {
+        "on": [{"key": "value"}, {"other_key": "other_value"}],
+        "else fail": ANY,
+    }
+
+
+def test_validate_grammar_recursive():
+    data = yaml.safe_load(
+        textwrap.dedent(
+            """
+            control: a string
+            grammar_str:
+              on amd64: another string
+              else:
+                to arm64: this other thing
+            grammar_strlist:
+              to amd64, arm64:
+                on riscv64:
+                  - a
+                  - string
+                  - list
+                else:
+                  on s390x:
+                    - we're
+                    - "on"
+                    - s390x
+                  else fail:
+              else:
+                - other
+                - stuff
+            grammar_single_entry_dictlist:
+              on arch, other_arch:
+                 on other_arch:
+                    to yet_another_arch:
+                       - key: value
+                       - other_key: other_value
+                    else fail:
+                 else:
+                    - yet_another_key: yet_another_value
+              else fail:
+            """
+        )
+    )
+
+    v = ValidationTest(**data)
+    assert v.control == "a string"
+    assert v.grammar_str == {
+        "on": "another string",
+        "else": {
+            "to": "this other thing",
+        },
+    }
+    assert v.grammar_strlist == {
+        "to": {
+            "on": ["a", "string", "list"],
+            "else": {
+                "on": ["we're", "on", "s390x"],
+                "else fail": ANY,
+            },
+        },
+        "else": ["other", "stuff"],
+    }
+    assert v.grammar_single_entry_dictlist == {
+        "on": {
+            "on": {
+                "to": [{"key": "value"}, {"other_key": "other_value"}],
+                "else fail": ANY,
+            },
+            "else": [{"yet_another_key": "yet_another_value"}],
+        },
+        "else fail": ANY,
+    }
+
+
+def test_grammar_str_error():
+    class GrammarValidation(pydantic.BaseModel):
+        """Test validation of grammar-enabled types."""
+
+        x: GrammarStr
+
+    with pytest.raises(pydantic.ValidationError) as raised:
+        GrammarValidation(x=["foo"])  # type: ignore
+
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("x",)
+    assert err[0]["type"] == "type_error"
+    assert err[0]["msg"] == "value must be a string: ['foo']"
+
+
+def test_grammar_strlist_error():
+    class GrammarValidation(pydantic.BaseModel):
+        """Test validation of grammar-enabled types."""
+
+        x: GrammarStrList
+
+    with pytest.raises(pydantic.ValidationError) as raised:
+        GrammarValidation(x=["foo", 23])  # type: ignore
+
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("x",)
+    assert err[0]["type"] == "type_error"
+    assert err[0]["msg"] == "value must be a list of string: ['foo', 23]"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        23,
+        "string",
+        [{"a": 42}, "foo"],
+        [{"a": 42, "b": 43}],
+    ],
+)
+def test_grammar_single_entry_dictlist_error(value):
+    class GrammarValidation(pydantic.BaseModel):
+        """Test validation of grammar-enabled types."""
+
+        x: GrammarSingleEntryDictList
+
+    with pytest.raises(pydantic.ValidationError) as raised:
+        GrammarValidation(x=value)  # type: ignore
+
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("x",)
+    assert err[0]["type"] == "type_error"
+    assert err[0]["msg"] == (
+        f"value must be a list of single-entry dictionaries: {value!r}"
+    )
+
+
+def test_grammar_nested_error():
+    class GrammarValidation(pydantic.BaseModel):
+        """Test validation of grammar-enabled types."""
+
+        x: GrammarStr
+
+    with pytest.raises(pydantic.ValidationError) as raised:
+        GrammarValidation(
+            x={
+                "on arm64, amd64": {"on arm64": "foo", "else": 35},
+                "else": "baz",
+            }  # type: ignore
+        )
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("x",)
+    assert err[0]["type"] == "type_error"
+    assert err[0]["msg"] == "value must be a string: 35"
+
+
+def test_grammar_str_elsefail_error():
+    class GrammarValidation(pydantic.BaseModel):
+        """Test validation of grammar-enabled types."""
+
+        x: GrammarStr
+
+    with pytest.raises(pydantic.ValidationError) as raised:
+        GrammarValidation(x={"on arch": "foo", "else fail": "bar"})  # type: ignore
+
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("x",)
+    assert err[0]["type"] == "value_error"
+    assert err[0]["msg"] == "'else fail' must have no arguments"
+
+
+def test_grammar_try():
+    class GrammarValidation(pydantic.BaseModel):
+        """Test validation of grammar-enabled types."""
+
+        x: GrammarStr
+
+    with pytest.raises(pydantic.ValidationError) as raised:
+        GrammarValidation(x={"try": "foo"})  # type: ignore
+
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("x",)
+    assert err[0]["type"] == "value_error"
+    assert err[0]["msg"] == "'try' was removed from grammar, use 'on <arch>' instead"
+
+
+def test_grammar_extras():
+    class GrammarValidation(pydantic.BaseModel):
+        """Test validation of grammar-enabled types."""
+
+        x: GrammarStr
+
+    with pytest.raises(pydantic.ValidationError) as raised:
+        GrammarValidation(x={"on arm64": "foo", "foo": "bar"})  # type: ignore
+
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("x",)
+    assert err[0]["type"] == "value_error"
+    assert err[0]["msg"] == "invalid grammar key 'foo'"


### PR DESCRIPTION
Define types GrammarStr (for grammar-aware strings), GrammarStrList
(for grammar-aware string lists) and GrammarSingleEntryDictList (for
grammar-aware lists of single-entry dictionaries). The latter is used
used in the `build-environment` attribute of lifecycle parts.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
