### PR TITLE
fix: coerce numbers to strings

### DIFF
--- a/craft_grammar/create.py
+++ b/craft_grammar/create.py
@@ -29,6 +29,7 @@ CONFIG_TEMPLATE = """
         extra = "ignore"
         allow_mutation = False
         alias_generator = lambda s: s.replace("_", "-")
+        coerce_numbers_to_str = True
 """
 
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

I thought this PR and this craft-application PR (https://github.com/canonical/craft-application/pull/465) would fix the pydantic v2 regressions: https://github.com/canonical/snapcraft/issues/5017, https://github.com/canonical/snapcraft/issues/4978

Unfortunately this is not working.

TODO: add regression tests