### PR TITLE
fix: use the origin type when validating a grammar list

### DIFF
--- a/craft_grammar/models.py
+++ b/craft_grammar/models.py
@@ -74,6 +74,7 @@ class _GrammarBase(abc.ABC):
     ) -> list[T]:
         # Check if the type_ is supposed to be a list
         sub_type: Any = get_args(type_)
+        unsubscripted_type = get_origin(type_) or type_
 
         # handle typed list
         if sub_type:
@@ -121,7 +122,7 @@ class _GrammarBase(abc.ABC):
                     pass
                 else:
                     continue
-            if issubclass(type_, str):
+            if issubclass(unsubscripted_type, str):
                 if isinstance(item, dict):
                     errors.append(
                         pydantic_core.InitErrorDetails(


### PR DESCRIPTION
issubclass working on a GenericAlias was a bug that was fixed in python 3.13 (see https://github.com/python/cpython/issues/101162)

Fixes #81

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
