### PR TITLE
chore: fix new lints from ruff 0.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: fix-byte-order-marker
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.6"
+    rev: "v0.12.1"
     hooks:
       # Run the linter
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,6 +283,7 @@ ignore = [
     "A003",   # Class attribute shadowing built-in (reason: Class attributes don't often get bare references)
     "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
     # (reason: this creates long lines that get wrapped and reduces readability)
+    "PLW1641", # eq-without-hash (most of our classes should be unhashable)
 
     # Ignored due to conflicts with ruff's formatter:
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,10 @@
 name = "craft-grammar"
 description = "Provide python interfaces for using advanced grammar in craft-parts"
 dynamic = ["version", "readme"]
-dependencies = ["overrides", "pydantic~=2.0"]
+dependencies = [
+    "overrides",
+    "pydantic~=2.0",
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
@@ -176,7 +179,10 @@ strict = false
 line-length = 88
 target-version = "py310"
 src = ["craft_grammar", "tests"]
-extend-exclude = ["docs", "__pycache__"]
+extend-exclude = [
+    "docs",
+    "__pycache__",
+]
 
 [tool.ruff.format]
 docstring-code-format = true
@@ -287,7 +293,7 @@ ignore = [
     "TRY003", # Avoid specifying long messages outside the exception class
 
     # Craft Grammar specific entries
-    "PLW1641", # We don't really care about hashing grammar classes
+    "PLW1641",# We don't really care about hashing grammar classes
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,7 @@
 name = "craft-grammar"
 description = "Provide python interfaces for using advanced grammar in craft-parts"
 dynamic = ["version", "readme"]
-dependencies = [
-    "overrides",
-    "pydantic~=2.0",
-]
+dependencies = ["overrides", "pydantic~=2.0"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
@@ -179,10 +176,7 @@ strict = false
 line-length = 88
 target-version = "py310"
 src = ["craft_grammar", "tests"]
-extend-exclude = [
-    "docs",
-    "__pycache__",
-]
+extend-exclude = ["docs", "__pycache__"]
 
 [tool.ruff.format]
 docstring-code-format = true
@@ -291,6 +285,9 @@ ignore = [
 
     # Ignored due to common usage in current code
     "TRY003", # Avoid specifying long messages outside the exception class
+
+    # Craft Grammar specific entries
+    "PLW1641", # We don't really care about hashing grammar classes
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,9 +292,6 @@ ignore = [
 
     # Ignored due to common usage in current code
     "TRY003", # Avoid specifying long messages outside the exception class
-
-    # Craft Grammar specific entries
-    "PLW1641",# We don't really care about hashing grammar classes
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def project_main_module() -> types.ModuleType:
     """
     try:
         # This should be the project's main package; downstream projects must update this.
-        import craft_grammar
+        import craft_grammar  # noqa: PLC0415
 
         main_module = craft_grammar
     except ImportError:

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -31,7 +31,7 @@ class MyModel(BaseModel):
     # Primitive types
     str_value: str
     str_value_or_none: str | None
-    optional_str_value: Optional[str]  # noqa: UP007 (non-pep604-annotation)
+    optional_str_value: Optional[str]  # noqa: UP045 (use of optional)
     str_with_default: str = "string"
     str_or_non_with_default: str | None = "string or None"
     union_value: Union[str, int, None]  # noqa: UP007 (non-pep604-annotation)


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

Bumps the precommit ruff and fixes lint errors introduced by ruff 0.12. Cherry-picks https://github.com/canonical/starbase/pull/409