### PR TITLE
build: add craft_grammar_docs sub-package

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -1,0 +1,2 @@
+This directory contains documentation files that are meant to
+be shared and reused by applications using craft-grammar.

--- a/docs/common/__init__.py
+++ b/docs/common/__init__.py
@@ -1,0 +1,1 @@
+# This file exists to enable the craft_gramar_docs package to be produced.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,6 +177,7 @@ extensions = [
 # Excludes files or directories from processing
 exclude_patterns = [
     "README.md",  # Docs README
+    "common/README.md",  # Shared README
     "reuse",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,9 +130,11 @@ git_describe_command = [
     "*[^0-9.]*",
 ]
 
-[tool.setuptools.packages.find]
-include = ["*craft*"]
-namespaces = false
+# NOTE: Do not merge starbase's auto-find here, as we are intentionally adding two
+# packages using this manual description.
+[tool.setuptools.package-dir]
+"craft_grammar" = "craft_grammar"
+"craft_grammar_docs" = "docs/common"
 
 [tool.codespell]
 ignore-words-list = "Afor,buildd,crate,keyserver,comandos,ro,dedent,dedented"


### PR DESCRIPTION
Tested locally in Snapcraft.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
