### PR TITLE
ci: test on Python 3.14 and Ubuntu 26.04 (Resolute)

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -16,5 +16,7 @@ jobs:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
       lowest-python-version: "3.10"
-      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
-      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm", "self-hosted-linux-amd64-resolute-large"]'
+      fast-test-python-versions: '["3.10", "3.12", "3.14"]'
+      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm", "self-hosted-linux-amd64-resolute-large"]'
+      slow-test-python-versions: '["3.10", "3.12", "3.14"]'

--- a/craft_grammar/create.py
+++ b/craft_grammar/create.py
@@ -109,6 +109,13 @@ def _get_grammar_type_for(  # noqa: PLR0911,PLR0912 (too many returns/branches)
                 return f"Grammar{model_type.__name__}"
             return f"Grammar[{model_type.__name__}]"
 
+        case types.UnionType:
+            # Type is an expression like "str | int | None"
+            # A type like "str | None" becomes "Grammar[str] | None"
+            grammar_types = [_get_grammar_type_for(a) for a in args]
+            grammar_args = [t for t in grammar_types if t is not None]
+            return " | ".join(grammar_args)
+
         case typing.Union:
             # Type is either a Union[] or an Optional[]
             if len(args) == 2 and type(None) in args:  # noqa: PLR2004 (magic value)
@@ -129,13 +136,6 @@ def _get_grammar_type_for(  # noqa: PLR0911,PLR0912 (too many returns/branches)
                     union_args.append(str(arg))
             comma_args = ", ".join(union_args)
             return f"Grammar[Union[{comma_args}]]"
-
-        case types.UnionType:
-            # Type is an expression like "str | int | None"
-            # A type like "str | None" becomes "Grammar[str] | None"
-            grammar_types = [_get_grammar_type_for(a) for a in args]
-            grammar_args = [t for t in grammar_types if t is not None]
-            return " | ".join(grammar_args)
 
         case builtins.list | builtins.dict:
             # list[T] -> Grammar[list[T]]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,7 +223,7 @@ if "discourse_prefix" not in html_context and "discourse" in html_context:
 # Add configuration for intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "starflow": ("https://canonical-starflow.readthedocs-hosted.com", None),
+    "starflow": ("https://documentation.ubuntu.com/starflow/latest", None),
 }
 
 # Block Intersphinx from looking up external sources with internal references. In other

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.14",
 ]
 license = "GPL-3.0"
 requires-python = ">=3.10"

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -91,10 +91,6 @@ if sys.version_info >= (3, 14):
             "union_value: Grammar[Union[str, int, None]]",
             "union_value: Grammar[str] | Grammar[int] | None",
         )
-        .replace(
-            "str_or_non_with_default: Grammar[str] | None",
-            "str_or_non_with_default: Grammar[str] | None",  # No change needed here
-        )
     )
 
 

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -15,6 +15,7 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
+import sys
 from typing import List, Literal, Optional, Union  # noqa: UP035 (deprecated-import)
 
 from craft_grammar import create_grammar_model
@@ -79,6 +80,22 @@ class GrammarMyModel(BaseModel):
     alias_name: Grammar[int] = 1
     factory_field: Grammar[str] = ""
 """
+
+if sys.version_info >= (3, 14):
+    EXPECTED_GRAMMAR_MODEL = (
+        EXPECTED_GRAMMAR_MODEL.replace(
+            "optional_str_value: Optional[Grammar[str]]",
+            "optional_str_value: Grammar[str] | None",
+        )
+        .replace(
+            "union_value: Grammar[Union[str, int, None]]",
+            "union_value: Grammar[str] | Grammar[int] | None",
+        )
+        .replace(
+            "str_or_non_with_default: Grammar[str] | None",
+            "str_or_non_with_default: Grammar[str] | None",  # No change needed here
+        )
+    )
 
 
 def test_create_model():


### PR DESCRIPTION
This PR adds testing for Python 3.14 and Ubuntu 26.04 (Resolute) to the QA workflow. Resolute testing uses the 'self-hosted-linux-amd64-resolute-large' runner.