### PR TITLE
ci: add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# GitHub code owners. See:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Remember, the last match takes precedence.
+
+# Global owner
+*                    @mr-cal
+
+# Documentation owners
+/docs/               @canonical/starcraft-authors @mr-cal
+/docs/changelog.rst  @canonical/starcraft-reviewers
+
+# Code owner changes must be approved by a maintainer.
+/.github/CODEOWNERS  @canonical/starcraft-maintainers


### PR DESCRIPTION
Adds code owners.

(CRAFT-5209)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
