### PR TITLE
ci: align policy OSV scan inputs with starbase

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -14,4 +14,9 @@ jobs:
     name: Security scan
     uses: canonical/starflow/.github/workflows/scan-python.yaml@main
     with:
-      requirements-find-args: "! -path '*/tests/integration/*'"
+      osv-extra-args: "--config=osv-scanner.toml"
+      osv-exclude-paths: |
+        docs
+      uv-export-no-groups: |
+        docs
+        docs-sphinx-stack

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,1 @@
+# OSV Scanner configuration


### PR DESCRIPTION
## Summary
- update `.github/workflows/policy.yaml` security scan inputs to pass `--config=osv-scanner.toml`
- exclude `docs` from OSV scan paths and skip uv export groups `docs` and `docs-sphinx-stack`
- add root `osv-scanner.toml` placeholder config file

## Dependency/lockfile impact
- No dependency or lockfile changes were required because this fix only updates workflow inputs and adds scanner configuration metadata; project dependencies remain unchanged.

## Validation
- `make format`
- `make lint`
- `make test-fast`